### PR TITLE
Added search & embed for NVRTC library path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,7 @@ WORKDIR /work
 COPY . /work
 WORKDIR /work/gst-plugins-cuda
 RUN mkdir -p /opt/gstreamer-plugins \
-    && meson build -Dtests=disabled \
+    && meson build -Dtests=disabled -Dfind-nvrtc=enabled \
     && ninja -C build \
     && DESTDIR=/opt/gstreamer-plugins ninja install -C build
 

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -247,7 +247,7 @@ WORKDIR /work
 COPY . /work
 WORKDIR /work/gst-plugins-cuda
 RUN mkdir -p /opt/gstreamer-plugins \
-    && meson build -Dtests=disabled \
+    && meson build -Dtests=disabled -Dfind-nvrtc=enabled \
     && ninja -C build \
     && DESTDIR=/opt/gstreamer-plugins ninja install -C build
 

--- a/gst-plugins-cuda/gst-libs/gst/cuda/meson.build
+++ b/gst-plugins-cuda/gst-libs/gst/cuda/meson.build
@@ -76,6 +76,24 @@ if gstgl_dep.found()
   extra_cpp_args += ['-DHAVE_NVCODEC_GST_GL=1']
 endif
 
+if host_machine.system() != 'windows' and get_option('find-nvrtc').enabled()
+  found_nvrtc = run_command(
+    find_library_script,
+    'nvrtc',
+    '/usr/lib/x86_64-linux-gnu',
+    capture : true,
+    check : true
+  )
+
+  if found_nvrtc.returncode() == 0
+    nvrtc_path = found_nvrtc.stdout().strip()
+    message('Found NVRTC library at "' + nvrtc_path + '".')
+
+    extra_c_args += ['-DNVRTC_LIBPATH="' + nvrtc_path + '"']
+    extra_cpp_args += ['-DNVRTC_LIBPATH="' + nvrtc_path + '"']
+  endif
+endif
+
 gst_cuda_dependencies = [
   gst_dep,
   gstbase_dep,
@@ -86,8 +104,8 @@ gst_cuda_dependencies = [
 
 gst_cuda = library('gstcuda-' + api_version,
   gst_cuda_sources,
-  c_args : gst_plugins_cuda_args,
-  cpp_args : gst_plugins_cuda_args,
+  c_args : gst_plugins_cuda_args + extra_c_args,
+  cpp_args : gst_plugins_cuda_args + extra_cpp_args,
   include_directories : [configinc, libsinc, gst_cuda_incdirs],
   version : libversion,
   soversion : soversion,

--- a/gst-plugins-cuda/gst-libs/gst/cuda/meson.build
+++ b/gst-plugins-cuda/gst-libs/gst/cuda/meson.build
@@ -86,11 +86,15 @@ if host_machine.system() != 'windows' and get_option('find-nvrtc').enabled()
   )
 
   if found_nvrtc.returncode() == 0
-    nvrtc_path = found_nvrtc.stdout().strip()
-    message('Found NVRTC library at "' + nvrtc_path + '".')
+    nvrtc_paths = found_nvrtc.stdout().strip()
+    message('Found NVRTC library at: ')
 
-    extra_c_args += ['-DNVRTC_LIBPATH="' + nvrtc_path + '"']
-    extra_cpp_args += ['-DNVRTC_LIBPATH="' + nvrtc_path + '"']
+    foreach nvrtc_path : nvrtc_paths.split(':')
+      message('    ' + nvrtc_path)
+    endforeach
+
+    extra_c_args += ['-DNVRTC_LIBPATHS="' + nvrtc_paths + '"']
+    extra_cpp_args += ['-DNVRTC_LIBPATHS="' + nvrtc_paths + '"']
   endif
 endif
 

--- a/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
+++ b/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
@@ -102,6 +102,15 @@ gboolean gst_nvrtc_load_library(void)
     if(filename_env)
         module = g_module_open(filename_env, G_MODULE_BIND_LAZY);
 
+#ifdef NVRTC_LIBPATH
+    if(!module)
+    {
+        filename = g_strdup(NVRTC_LIBPATH);
+        fname = filename;
+        module = g_module_open(filename, G_MODULE_BIND_LAZY);
+    }
+#endif
+
     if(!module)
     {
 #ifndef G_OS_WIN32
@@ -136,6 +145,8 @@ gboolean gst_nvrtc_load_library(void)
         }
 #endif
     }
+
+    GST_DEBUG("NVRTC library at %s was loaded.", fname);
 
     if(module == NULL)
     {

--- a/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
+++ b/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
@@ -102,12 +102,28 @@ gboolean gst_nvrtc_load_library(void)
     if(filename_env)
         module = g_module_open(filename_env, G_MODULE_BIND_LAZY);
 
-#ifdef NVRTC_LIBPATH
+#ifdef NVRTC_LIBPATHS
     if(!module)
     {
-        filename = g_strdup(NVRTC_LIBPATH);
-        fname = filename;
-        module = g_module_open(filename, G_MODULE_BIND_LAZY);
+        gchar **lib_paths = g_strsplit(NVRTC_LIBPATHS, ":", -1);
+
+        for(
+            gchar **current_path = lib_paths;
+            *current_path != NULL;
+            current_path++
+        )
+        {
+            module = g_module_open(*current_path, G_MODULE_BIND_LAZY);
+
+            if(module)
+            {
+                filename = g_strdup(*current_path);
+                fname = filename;
+                break;
+            }
+        }
+
+        g_strfreev(lib_paths);
     }
 #endif
 

--- a/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
+++ b/gst-plugins-cuda/gst-libs/gst/cuda/nvcodec/gstnvrtcloader.c
@@ -162,8 +162,6 @@ gboolean gst_nvrtc_load_library(void)
 #endif
     }
 
-    GST_DEBUG("NVRTC library at %s was loaded.", fname);
-
     if(module == NULL)
     {
         GST_WARNING(
@@ -171,6 +169,8 @@ gboolean gst_nvrtc_load_library(void)
         g_free(filename);
         return FALSE;
     }
+
+    GST_DEBUG("NVRTC library at %s was loaded.", filename);
 
     vtable = &gst_nvrtc_vtable;
 

--- a/gst-plugins-cuda/meson.build
+++ b/gst-plugins-cuda/meson.build
@@ -414,6 +414,8 @@ gnome = import('gnome')
 
 presetdir = join_paths(get_option('datadir'), 'gstreamer-' + api_version, 'presets')
 
+find_library_script = find_program('scripts/find-library.py')
+
 subdir('gst-libs')
 subdir('sys')
 subdir('tests')

--- a/gst-plugins-cuda/meson_options.txt
+++ b/gst-plugins-cuda/meson_options.txt
@@ -23,3 +23,7 @@ option('package-name', type : 'string', yield : true,
        description : 'package name to use in plugins')
 option('package-origin', type : 'string', value : 'Unknown package origin', yield : true,
        description : 'package origin URL to use in plugins')
+
+# CUDA library options
+option('find-nvrtc', type : 'feature', value : 'disabled',
+       description: 'Enables finding and embedding the NVRTC library path into the GStreamer CUDA library.')

--- a/gst-plugins-cuda/scripts/find-library.py
+++ b/gst-plugins-cuda/scripts/find-library.py
@@ -8,9 +8,13 @@ assert(len(sys.argv) >= 3)
 lib_name = sys.argv[1]
 lib_search_paths = sys.argv[2:]
 
+lib_paths = []
+
 for lib_search_path in lib_search_paths:
-    found_libs = sorted(list(pathlib.Path(lib_search_path).glob(f"lib{lib_name}.so*")))
-    if len(found_libs) > 0:
-        print(found_libs[0])
-        sys.exit(0)
-sys.exit(1)
+    lib_paths += list(pathlib.Path(lib_search_path).glob(f"lib{lib_name}.so*"))
+
+if not lib_paths:
+    sys.exit(1)
+
+print(":".join([str(lib_path) for lib_path in lib_paths]))
+sys.exit(0)

--- a/gst-plugins-cuda/scripts/find-library.py
+++ b/gst-plugins-cuda/scripts/find-library.py
@@ -17,4 +17,3 @@ if not lib_paths:
     sys.exit(1)
 
 print(":".join([str(lib_path) for lib_path in lib_paths]))
-sys.exit(0)

--- a/gst-plugins-cuda/scripts/find-library.py
+++ b/gst-plugins-cuda/scripts/find-library.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+
+assert(len(sys.argv) >= 3)
+
+lib_name = sys.argv[1]
+lib_search_paths = sys.argv[2:]
+
+for lib_search_path in lib_search_paths:
+    found_libs = sorted(list(pathlib.Path(lib_search_path).glob(f"lib{lib_name}.so*")))
+    if len(found_libs) > 0:
+        print(found_libs[0])
+        sys.exit(0)
+sys.exit(1)


### PR DESCRIPTION
Due to issues with loading NVRTC without having `nvidia-cuda-dev` installed (due to missing the `libnvrtc.so` symlink/library in the `libnvrtc11.2` package), this pull-request introduces a basic script to search for the NVRTC library and add the path as a compile-time definition.

The script is not used by default, it requires the meson project to be configured with `find-nvrtc` set to `enabled`. I.E. Using `-Dfind-nvrtc=enabled` when configuring or setting-up a meson build directory.

This compile-time definition can be overriden via the `GST_NVCODEC_NVRTC_LIBNAME` environment variable as per usual. And if NVRTC is not found, then it will attempt to load `libnvrtc.so` from the standard library path as per usual.